### PR TITLE
Embed se.sawano.java:alphanumeric-comparator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,15 @@
         <version>2.20</version>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Embed-Dependency>alphanumeric-comparator</Embed-Dependency>
+          </instructions>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Embed the se.sawano.java alphanumeric-comparator since it was removed
from nexus.  See https://github.com/sonatype/nexus-internal/pull/3514