### PR TITLE
BrowseUnsupported fixes

### DIFF
--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RGroupRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RGroupRecipe.groovy
@@ -26,10 +26,8 @@ import org.sonatype.nexus.repository.group.GroupHandler
 import org.sonatype.nexus.repository.http.HttpHandlers
 import org.sonatype.nexus.repository.types.GroupType
 import org.sonatype.nexus.repository.view.ConfigurableViewFacet
-import org.sonatype.nexus.repository.view.Route
 import org.sonatype.nexus.repository.view.Router
 import org.sonatype.nexus.repository.view.ViewFacet
-import org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler
 
 /**
  * R group repository recipe.

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RGroupRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RGroupRecipe.groovy
@@ -70,6 +70,8 @@ class RGroupRecipe
   private ViewFacet configure(final ConfigurableViewFacet facet) {
     Router.Builder builder = new Router.Builder()
 
+    addBrowseUnsupportedRoute(builder)
+
     builder.route(packagesMatcher()
         .handler(timingHandler)
         .handler(assetKindHandler.rcurry(AssetKind.PACKAGES))
@@ -86,11 +88,6 @@ class RGroupRecipe
         .handler(exceptionHandler)
         .handler(handlerContributor)
         .handler(standardGroupHandler)
-        .create())
-
-    builder.route(new Route.Builder()
-        .matcher(BrowseUnsupportedHandler.MATCHER)
-        .handler(browseUnsupportedHandler)
         .create())
 
     builder.defaultHandlers(HttpHandlers.notFound())

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RHostedRecipe.groovy
@@ -24,10 +24,8 @@ import org.sonatype.nexus.repository.Type
 import org.sonatype.nexus.repository.http.HttpHandlers
 import org.sonatype.nexus.repository.types.HostedType
 import org.sonatype.nexus.repository.view.ConfigurableViewFacet
-import org.sonatype.nexus.repository.view.Route
 import org.sonatype.nexus.repository.view.Router
 import org.sonatype.nexus.repository.view.ViewFacet
-import org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler
 
 import static org.sonatype.nexus.repository.r.internal.AssetKind.PACKAGES
 import static org.sonatype.nexus.repository.r.internal.AssetKind.ARCHIVE

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RHostedRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RHostedRecipe.groovy
@@ -71,6 +71,8 @@ class RHostedRecipe
   private ViewFacet configure(final ConfigurableViewFacet facet) {
     Router.Builder builder = new Router.Builder()
 
+    addBrowseUnsupportedRoute(builder)
+
     builder.route(packagesMatcher()
         .handler(timingHandler)
         .handler(assetKindHandler.rcurry(PACKAGES))
@@ -107,11 +109,6 @@ class RHostedRecipe
         .handler(contentHeadersHandler)
         .handler(unitOfWorkHandler)
         .handler(hostedHandlers.putArchive)
-        .create())
-
-    builder.route(new Route.Builder()
-        .matcher(BrowseUnsupportedHandler.MATCHER)
-        .handler(browseUnsupportedHandler)
         .create())
 
     builder.defaultHandlers(HttpHandlers.notFound())

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RProxyRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RProxyRecipe.groovy
@@ -86,6 +86,8 @@ class RProxyRecipe
   private ViewFacet configure(final ConfigurableViewFacet facet) {
     Router.Builder builder = new Router.Builder()
 
+    addBrowseUnsupportedRoute(builder)
+
     builder.route(packagesMatcher()
         .handler(timingHandler)
         .handler(assetKindHandler.rcurry(PACKAGES))
@@ -111,11 +113,6 @@ class RProxyRecipe
         .handler(contentHeadersHandler)
         .handler(unitOfWorkHandler)
         .handler(proxyHandler)
-        .create())
-
-    builder.route(new Route.Builder()
-        .matcher(BrowseUnsupportedHandler.MATCHER)
-        .handler(browseUnsupportedHandler)
         .create())
 
     builder.defaultHandlers(HttpHandlers.notFound())

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RProxyRecipe.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RProxyRecipe.groovy
@@ -28,10 +28,8 @@ import org.sonatype.nexus.repository.proxy.ProxyHandler
 import org.sonatype.nexus.repository.types.ProxyType
 import org.sonatype.nexus.repository.purge.PurgeUnusedFacet
 import org.sonatype.nexus.repository.view.ConfigurableViewFacet
-import org.sonatype.nexus.repository.view.Route
 import org.sonatype.nexus.repository.view.Router
 import org.sonatype.nexus.repository.view.ViewFacet
-import org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler
 
 import static org.sonatype.nexus.repository.r.internal.AssetKind.PACKAGES
 import static org.sonatype.nexus.repository.r.internal.AssetKind.ARCHIVE

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RRecipeSupport.groovy
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RRecipeSupport.groovy
@@ -29,7 +29,6 @@ import org.sonatype.nexus.repository.storage.UnitOfWorkHandler
 import org.sonatype.nexus.repository.view.ConfigurableViewFacet
 import org.sonatype.nexus.repository.view.Context
 import org.sonatype.nexus.repository.view.Route.Builder
-import org.sonatype.nexus.repository.view.handlers.BrowseUnsupportedHandler
 import org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler
 import org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler
 import org.sonatype.nexus.repository.view.handlers.ExceptionHandler
@@ -84,9 +83,6 @@ abstract class RRecipeSupport
 
   @Inject
   UnitOfWorkHandler unitOfWorkHandler
-
-  @Inject
-  BrowseUnsupportedHandler browseUnsupportedHandler
 
   @Inject
   HandlerContributor handlerContributor


### PR DESCRIPTION
Based on a convo with @mcculls , this implements the new way of doing Browse Unsupported

This pull request makes the following changes:
* Call the method that's now available from `RecipeSupport` in the Recipes
* Remove the BrowseUnsupportedHandler 

This reduces log spam
