### PR TITLE
Update to Java8 alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ we would like things to flow.
 ### Requirements
 
 * [Apache Maven 3.3.3+](https://maven.apache.org/install.html)
-* [Java 8+](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+* [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
 * Network access to https://repository.sonatype.org/content/groups/sonatype-public-grid
 
 Also, there is a good amount of information available at [Bundle Development](https://help.sonatype.com/display/NXRM3/Bundle+Development+Overview)


### PR DESCRIPTION
This pull request makes the following changes:
* Adjusted readme to remove + on java 8.  User had trouble with Java 11, NXRM only "supports" java 8 itself so that's what we test.  The link also only goes to 8.

It relates to the following issue #s:
* "Fixes #57"