### PR TITLE
ISSUE-39: Updated RPackagesUtils buildPackages method to include...

### DIFF
--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RAttributes.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RAttributes.java
@@ -28,6 +28,8 @@ public final class RAttributes
 
   public static final String P_SUGGESTS = "Suggests";
 
+  public static final String P_LINKINGTO = "LinkingTo";
+
   public static final String P_LICENSE = "License";
 
   public static final String P_NEEDS_COMPILATION = "NeedsCompilation";

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilder.java
@@ -26,6 +26,7 @@ import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LICENSE;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_NEEDS_COMPILATION;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_PACKAGE;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_SUGGESTS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LINKINGTO;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_VERSION;
 
 /**
@@ -87,6 +88,7 @@ public class RPackagesBuilder
         newInformation.put(P_DEPENDS, asset.formatAttributes().get(P_DEPENDS, String.class));
         newInformation.put(P_IMPORTS, asset.formatAttributes().get(P_IMPORTS, String.class));
         newInformation.put(P_SUGGESTS, asset.formatAttributes().get(P_SUGGESTS, String.class));
+        newInformation.put(P_LINKINGTO, asset.formatAttributes().get(P_LINKINGTO, String.class));
         newInformation.put(P_LICENSE, asset.formatAttributes().get(P_LICENSE, String.class));
         newInformation.put(P_NEEDS_COMPILATION, asset.formatAttributes().get(P_NEEDS_COMPILATION, String.class));
 

--- a/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesUtils.java
+++ b/src/main/java/org/sonatype/nexus/repository/r/internal/RPackagesUtils.java
@@ -43,6 +43,7 @@ import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LICENSE;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_NEEDS_COMPILATION;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_PACKAGE;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_SUGGESTS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LINKINGTO;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_VERSION;
 import static org.sonatype.nexus.repository.r.internal.RMetadataUtils.parseDescriptionFile;
 
@@ -94,6 +95,7 @@ public final class RPackagesUtils
           headers.addHeader(P_DEPENDS, entry.get(P_DEPENDS));
           headers.addHeader(P_IMPORTS, entry.get(P_IMPORTS));
           headers.addHeader(P_SUGGESTS, entry.get(P_SUGGESTS));
+          headers.addHeader(P_LINKINGTO, entry.get(P_LINKINGTO));
           headers.addHeader(P_LICENSE, entry.get(P_LICENSE));
           headers.addHeader(P_NEEDS_COMPILATION, entry.get(P_NEEDS_COMPILATION));
           Enumeration<String> headerLines = headers.getAllHeaderLines();

--- a/src/test/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilderTest.java
+++ b/src/test/java/org/sonatype/nexus/repository/r/internal/RPackagesBuilderTest.java
@@ -31,6 +31,7 @@ import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LICENSE;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_NEEDS_COMPILATION;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_PACKAGE;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_SUGGESTS;
+import static org.sonatype.nexus.repository.r.internal.RAttributes.P_LINKINGTO;
 import static org.sonatype.nexus.repository.r.internal.RAttributes.P_VERSION;
 
 /**
@@ -58,6 +59,7 @@ public class RPackagesBuilderTest
     assertThat(packageA.get(P_DEPENDS), is("Depends:/foo/bar/a-3"));
     assertThat(packageA.get(P_IMPORTS), is("Imports:/foo/bar/a-3"));
     assertThat(packageA.get(P_SUGGESTS), is("Suggests:/foo/bar/a-3"));
+    assertThat(packageA.get(P_LINKINGTO), is("LinkingTo:/foo/bar/a-3"));
     assertThat(packageA.get(P_LICENSE), is("License:/foo/bar/a-3"));
     assertThat(packageA.get(P_NEEDS_COMPILATION), is("NeedsCompilation:/foo/bar/a-3"));
 
@@ -67,6 +69,7 @@ public class RPackagesBuilderTest
     assertThat(packageB.get(P_DEPENDS), is("Depends:/foo/bar/b-4"));
     assertThat(packageB.get(P_IMPORTS), is("Imports:/foo/bar/b-4"));
     assertThat(packageB.get(P_SUGGESTS), is("Suggests:/foo/bar/b-4"));
+    assertThat(packageB.get(P_LINKINGTO), is("LinkingTo:/foo/bar/b-4"));
     assertThat(packageB.get(P_LICENSE), is("License:/foo/bar/b-4"));
     assertThat(packageB.get(P_NEEDS_COMPILATION), is("NeedsCompilation:/foo/bar/b-4"));
   }
@@ -78,6 +81,7 @@ public class RPackagesBuilderTest
     when(formatAttributes.get(P_DEPENDS, String.class)).thenReturn("Depends:" + assetName);
     when(formatAttributes.get(P_IMPORTS, String.class)).thenReturn("Imports:" + assetName);
     when(formatAttributes.get(P_SUGGESTS, String.class)).thenReturn("Suggests:" + assetName);
+    when(formatAttributes.get(P_LINKINGTO, String.class)).thenReturn("LinkingTo:" + assetName);
     when(formatAttributes.get(P_LICENSE, String.class)).thenReturn("License:" + assetName);
     when(formatAttributes.get(P_NEEDS_COMPILATION, String.class)).thenReturn("NeedsCompilation:" + assetName);
 


### PR DESCRIPTION
...LinkingTo in the package headers.

Signed-off-by: Kendal Montgomery <kmontgomery@cbuscollaboratory.com>

This pull request makes the following changes:
* Updates the repository so that grouped repositories output the correct LinkingTo headers so that LinkingTo dependencies are also considered when installing package dependences from a grouped repository URL.

It relates to the following issue #s:
* At least partially fixes Issue 39 in the nexus-repository-r project. (I'm not certain what all the differences were, but linking to being missing in the headers definitely causes the problem mentioned, for instance, with the BH package in the example).