### PR TITLE
nexus-cleanup scope should be 'provided' …

### DIFF
--- a/nexus-repository-r/pom.xml
+++ b/nexus-repository-r/pom.xml
@@ -70,6 +70,7 @@
     <dependency>
       <groupId>org.sonatype.nexus</groupId>
       <artifactId>nexus-cleanup</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
… to avoid leaking NXRM dependencies into the plugin's feature.xml