### PR TITLE
NEXUS-22489 fixed IT updates

### DIFF
--- a/nexus-repository-r-it/pom.xml
+++ b/nexus-repository-r-it/pom.xml
@@ -88,6 +88,17 @@
       <version>${nxrm-version}</version>
       <type>zip</type>
       <scope>test</scope>
+      <exclusions>
+        <!-- Avoid leaking older r plugins from distro -->
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-repository-r</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.sonatype.nexus.plugins</groupId>
+          <artifactId>nexus-restore-r</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RGroupIT.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RGroupIT.java
@@ -16,10 +16,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 
 import org.sonatype.goodies.httpfixture.server.fluent.Server;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.security.subject.FakeAlmightySubject;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 
 import org.apache.http.HttpResponse;
 import org.apache.shiro.util.ThreadContext;
@@ -32,9 +30,9 @@ import org.ops4j.pax.exam.Option;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.error;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.file;
+import static org.sonatype.nexus.plugins.r.internal.RITConfig.configureRWithMetadataProcessingInterval;
 import static org.sonatype.nexus.repository.http.HttpStatus.NOT_FOUND;
 import static org.sonatype.nexus.repository.http.HttpStatus.OK;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
@@ -56,12 +54,7 @@ public class RGroupIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-r"),
-        editConfigurationFileExtend(NEXUS_PROPERTIES_FILE, "nexus.r.packagesBuilder.interval",
-            String.valueOf(METADATA_PROCESSING_DELAY_MILLIS))
-    );
+    return configureRWithMetadataProcessingInterval();
   }
 
   @Before

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RHostedIT.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RHostedIT.java
@@ -18,12 +18,10 @@ import java.nio.file.Files;
 import java.util.List;
 
 import org.sonatype.nexus.common.app.BaseUrlHolder;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.ComponentMaintenance;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 
 import org.apache.http.HttpResponse;
 import org.junit.Before;
@@ -38,7 +36,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.sonatype.nexus.plugins.r.internal.RITConfig.configureRWithMetadataProcessingInterval;
 import static org.sonatype.nexus.repository.http.HttpStatus.BAD_REQUEST;
 import static org.sonatype.nexus.repository.http.HttpStatus.NOT_FOUND;
 import static org.sonatype.nexus.repository.r.internal.util.PackageValidator.NOT_VALID_EXTENSION_ERROR_MESSAGE;
@@ -53,12 +51,7 @@ public class RHostedIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-r"),
-        editConfigurationFileExtend(NEXUS_PROPERTIES_FILE, "nexus.r.packagesBuilder.interval",
-            String.valueOf(METADATA_PROCESSING_DELAY_MILLIS))
-    );
+    return configureRWithMetadataProcessingInterval();
   }
 
   @Before

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITConfig.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITConfig.java
@@ -1,3 +1,15 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2017-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
 package org.sonatype.nexus.plugins.r.internal;
 
 import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITConfig.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITConfig.java
@@ -1,0 +1,33 @@
+package org.sonatype.nexus.plugins.r.internal;
+
+import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
+import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
+
+import org.ops4j.pax.exam.Option;
+
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.sonatype.nexus.pax.exam.NexusPaxExamSupport.NEXUS_PROPERTIES_FILE;
+import static org.sonatype.nexus.pax.exam.NexusPaxExamSupport.nexusFeature;
+
+public class RITConfig
+{
+  // Immediately start metadata processing
+  public static final long METADATA_PROCESSING_DELAY_MILLIS = 0L;
+
+  public static Option[] configureRBase() {
+    return NexusPaxExamSupport.options(
+        NexusITSupport.configureNexusBase(),
+        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-r"),
+        systemProperty("nexus-exclude-features").value("nexus-cma-community")
+    );
+  }
+
+  public static Option[] configureRWithMetadataProcessingInterval() {
+    return NexusPaxExamSupport.options(
+        configureRBase(),
+        editConfigurationFileExtend(NEXUS_PROPERTIES_FILE, "nexus.r.packagesBuilder.interval",
+            String.valueOf(METADATA_PROCESSING_DELAY_MILLIS))
+    );
+  }
+}

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITSupport.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITSupport.java
@@ -30,6 +30,7 @@ import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.StorageTx;
 import org.sonatype.nexus.testsuite.testsupport.RepositoryITSupport;
+
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.http.HttpEntity;
@@ -55,7 +56,6 @@ import static org.hamcrest.Matchers.is;
 public class RITSupport
     extends RepositoryITSupport
 {
-
   // Interval to wait for metadata is processed
   public static final long METADATA_PROCESSING_WAIT_INTERVAL_MILLIS = 1000L;
 

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITSupport.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RITSupport.java
@@ -55,8 +55,6 @@ import static org.hamcrest.Matchers.is;
 public class RITSupport
     extends RepositoryITSupport
 {
-  // Immediately start metadata processing
-  public static final long METADATA_PROCESSING_DELAY_MILLIS = 0L;
 
   // Interval to wait for metadata is processed
   public static final long METADATA_PROCESSING_WAIT_INTERVAL_MILLIS = 1000L;

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RProxyIT.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RProxyIT.java
@@ -16,12 +16,10 @@ import java.io.IOException;
 
 import org.sonatype.goodies.httpfixture.server.fluent.Server;
 import org.sonatype.nexus.common.app.BaseUrlHolder;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.ComponentMaintenance;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -38,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.error;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.file;
+import static org.sonatype.nexus.plugins.r.internal.RITConfig.configureRBase;
 import static org.sonatype.nexus.repository.http.HttpStatus.NOT_FOUND;
 import static org.sonatype.nexus.repository.storage.AssetEntityAdapter.P_ASSET_KIND;
 
@@ -52,10 +51,7 @@ public class RProxyIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-r")
-    );
+    return configureRBase();
   }
 
   @Before

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RRoutingRuleIT.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/RRoutingRuleIT.java
@@ -19,9 +19,7 @@ import java.util.Map;
 import org.sonatype.goodies.httpfixture.server.fluent.Behaviours;
 import org.sonatype.goodies.httpfixture.server.fluent.Server;
 import org.sonatype.nexus.common.entity.EntityId;
-import org.sonatype.nexus.pax.exam.NexusPaxExamSupport;
 import org.sonatype.nexus.repository.Repository;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 
 import org.junit.After;
 import org.junit.Before;
@@ -31,6 +29,7 @@ import org.ops4j.pax.exam.Option;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.sonatype.nexus.plugins.r.internal.RITConfig.configureRBase;
 
 /**
  * @since 1.1.0
@@ -44,10 +43,7 @@ public class RRoutingRuleIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-r")
-    );
+    return configureRBase();
   }
 
   @Before

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/cleanup/CleanupTaskRIT.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/cleanup/CleanupTaskRIT.java
@@ -24,7 +24,6 @@ import org.sonatype.nexus.plugins.r.internal.RITSupport.TestPackage;
 import org.sonatype.nexus.plugins.r.internal.fixtures.RepositoryRuleR;
 import org.sonatype.nexus.repository.Repository;
 import org.sonatype.nexus.repository.storage.Component;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.nexus.testsuite.testsupport.cleanup.CleanupITSupport;
 
 import org.apache.http.entity.ByteArrayEntity;
@@ -37,11 +36,10 @@ import org.ops4j.pax.exam.Option;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFileExtend;
+import static org.sonatype.nexus.plugins.r.internal.RITConfig.configureRWithMetadataProcessingInterval;
 import static org.sonatype.nexus.plugins.r.internal.RITSupport.AGRICOLAE_101_TARGZ;
 import static org.sonatype.nexus.plugins.r.internal.RITSupport.AGRICOLAE_121_TARGZ;
 import static org.sonatype.nexus.plugins.r.internal.RITSupport.AGRICOLAE_131_TARGZ;
-import static org.sonatype.nexus.plugins.r.internal.RITSupport.METADATA_PROCESSING_DELAY_MILLIS;
 import static org.sonatype.nexus.plugins.r.internal.RITSupport.METADATA_PROCESSING_WAIT_INTERVAL_MILLIS;
 import static org.sonatype.nexus.repository.http.HttpStatus.OK;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
@@ -58,12 +56,7 @@ public class CleanupTaskRIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-r"),
-        editConfigurationFileExtend(NEXUS_PROPERTIES_FILE, "nexus.r.packagesBuilder.interval",
-            String.valueOf(METADATA_PROCESSING_DELAY_MILLIS))
-    );
+    return configureRWithMetadataProcessingInterval();
   }
 
   @Before

--- a/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/restore/RRestoreBlobIT.java
+++ b/nexus-repository-r-it/src/test/java/org/sonatype/nexus/plugins/r/internal/restore/RRestoreBlobIT.java
@@ -31,7 +31,6 @@ import org.sonatype.nexus.repository.r.internal.RFormat;
 import org.sonatype.nexus.repository.storage.Asset;
 import org.sonatype.nexus.repository.storage.AssetEntityAdapter;
 import org.sonatype.nexus.repository.storage.StorageTx;
-import org.sonatype.nexus.testsuite.testsupport.NexusITSupport;
 import org.sonatype.nexus.testsuite.testsupport.blobstore.restore.BlobstoreRestoreTestHelper;
 
 import org.hamcrest.Matchers;
@@ -47,6 +46,7 @@ import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.file;
 import static org.sonatype.nexus.blobstore.api.BlobAttributesConstants.HEADER_PREFIX;
 import static org.sonatype.nexus.blobstore.api.BlobStore.BLOB_NAME_HEADER;
 import static org.sonatype.nexus.blobstore.api.BlobStore.CONTENT_TYPE_HEADER;
+import static org.sonatype.nexus.plugins.r.internal.RITConfig.configureRBase;
 import static org.sonatype.nexus.repository.storage.Bucket.REPO_NAME_HEADER;
 
 public class RRestoreBlobIT
@@ -76,8 +76,7 @@ public class RRestoreBlobIT
   @Configuration
   public static Option[] configureNexus() {
     return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-r"),
+        configureRBase(),
         nexusFeature("org.sonatype.nexus.plugins", "nexus-restore-r")
     );
   }

--- a/nexus-repository-r/src/test/java/org/sonatype/nexus/repository/r/internal/util/RFacetUtilsTest.java
+++ b/nexus-repository-r/src/test/java/org/sonatype/nexus/repository/r/internal/util/RFacetUtilsTest.java
@@ -107,7 +107,7 @@ public class RFacetUtilsTest
   @Test
   public void content() throws Exception {
     Content content = toContent(asset, blob);
-    assertThat(content.getAttributes().get("lastModified"), is(notNullValue()));
+    assertThat(content.getAttributes().get("last_modified"), is(notNullValue()));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.23.0-01</version>
+    <version>3.25.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>nexus-repository-base</artifactId>
@@ -47,7 +47,7 @@
   </distributionManagement>
 
   <properties>
-    <nxrm-version>3.23.0-01</nxrm-version>
+    <nxrm-version>3.25.0-SNAPSHOT</nxrm-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
ITs now use the actual repository code instead of the version of the plugin from the parent (NXRM)

The issue explains the problem for R format https://issues.sonatype.org/browse/NEXUS-22489